### PR TITLE
Transition from SUPPORT_*

### DIFF
--- a/custom_components/localtuya/vacuum.py
+++ b/custom_components/localtuya/vacuum.py
@@ -11,15 +11,7 @@ from homeassistant.components.vacuum import (
     STATE_IDLE,
     STATE_PAUSED,
     STATE_RETURNING,
-    SUPPORT_BATTERY,
-    SUPPORT_FAN_SPEED,
-    SUPPORT_LOCATE,
-    SUPPORT_PAUSE,
-    SUPPORT_RETURN_HOME,
-    SUPPORT_START,
-    SUPPORT_STATE,
-    SUPPORT_STATUS,
-    SUPPORT_STOP,
+    VacuumEntityFeature,
     StateVacuumEntity,
 )
 
@@ -120,24 +112,24 @@ class LocaltuyaVacuum(LocalTuyaEntity, StateVacuumEntity):
         _LOGGER.debug("Initialized vacuum [%s]", self.name)
 
     @property
-    def supported_features(self):
+    def supported_features(self) -> VacuumEntityFeature:
         """Flag supported features."""
         supported_features = (
-            SUPPORT_START
-            | SUPPORT_PAUSE
-            | SUPPORT_STOP
-            | SUPPORT_STATUS
-            | SUPPORT_STATE
+            VacuumEntityFeature.START
+            | VacuumEntityFeature.PAUSE
+            | VacuumEntityFeature.STOP
+            | VacuumEntityFeature.STATUS
+            | VacuumEntityFeature.STATE
         )
 
         if self.has_config(CONF_RETURN_MODE):
-            supported_features = supported_features | SUPPORT_RETURN_HOME
+            supported_features = supported_features | VacuumEntityFeature.RETURN_HOME
         if self.has_config(CONF_FAN_SPEED_DP):
-            supported_features = supported_features | SUPPORT_FAN_SPEED
+            supported_features = supported_features | VacuumEntityFeature.FAN_SPEED
         if self.has_config(CONF_BATTERY_DP):
-            supported_features = supported_features | SUPPORT_BATTERY
+            supported_features = supported_features | VacuumEntityFeature.BATTERY
         if self.has_config(CONF_LOCATE_DP):
-            supported_features = supported_features | SUPPORT_LOCATE
+            supported_features = supported_features | VacuumEntityFeature.LOCATE
 
         return supported_features
 


### PR DESCRIPTION
    Move from SUPPORT_* constants  from vacuum that were deprecated over a year ago
    re: https://developers.home-assistant.io/blog/2022/04/02/support-constants-deprecation/